### PR TITLE
Add workflow concurrency config

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -6,13 +6,14 @@ on:
   pull_request_review_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   bonk:
     if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
-    concurrency:
-      group: pr-${{ github.event.pull_request.number }}
-      cancel-in-progress: false
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
Moves concurrency config from job-level to top-level and updates the group key to cover both issue comments and PR review comments.

- groups runs by workflow name + issue/PR number
- `cancel-in-progress: false` ensures running jobs complete before new ones start