### PR TITLE
react to codex triggers

### DIFF
--- a/.github/scripts/codex/context.js
+++ b/.github/scripts/codex/context.js
@@ -51,6 +51,7 @@ module.exports = async ({ github, context, core }) => {
   core.setOutput("head_ref", headRef);
   core.setOutput("head_repo", headRepo);
   core.setOutput("review_comment_id", context.eventName === "pull_request_review_comment" ? payload.comment.id : "");
+  core.setOutput("reaction_subject_id", payload.comment?.node_id ?? payload.review?.node_id ?? "");
   core.setOutput("target_issue_number", targetIssueNumber);
   core.setOutput("trigger_url", payload.comment?.html_url ?? payload.review?.html_url ?? payload.issue?.html_url ?? "");
 };

--- a/.github/scripts/codex/react.js
+++ b/.github/scripts/codex/react.js
@@ -1,0 +1,20 @@
+module.exports = async ({ github, core }) => {
+  const subjectId = process.env.REACTION_SUBJECT_ID;
+  if (!subjectId) {
+    return;
+  }
+
+  try {
+    await github.graphql(`
+      mutation AddReaction($subjectId: ID!) {
+        addReaction(input: { subjectId: $subjectId, content: THUMBS_UP }) {
+          reaction {
+            content
+          }
+        }
+      }
+    `, { subjectId });
+  } catch (error) {
+    core.warning(`Could not add thumbs-up reaction: ${error.message}`);
+  }
+};

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -13,6 +13,51 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  acknowledge:
+    if: >
+      github.event.sender.type != 'Bot' &&
+      (
+        (github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/codex') || startsWith(github.event.comment.body, '/review'))) ||
+        (github.event_name == 'pull_request_review' && (startsWith(github.event.review.body, '/codex') || startsWith(github.event.review.body, '/review'))) ||
+        (github.event_name == 'pull_request_review_comment' && (startsWith(github.event.comment.body, '/codex') || startsWith(github.event.comment.body, '/review')))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout workflow scripts
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: .github/scripts/codex
+
+      - name: Copy workflow scripts
+        run: |
+          mkdir -p "$RUNNER_TEMP/codex-scripts"
+          cp .github/scripts/codex/*.js "$RUNNER_TEMP/codex-scripts/"
+
+      - name: Determine trigger context
+        id: context
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = require(`${process.env.RUNNER_TEMP}/codex-scripts/context.js`);
+            await run({ github, context, core });
+
+      - name: React to trigger
+        if: steps.context.outputs.is_valid == 'true' && steps.context.outputs.can_run == 'true'
+        uses: actions/github-script@v7
+        env:
+          REACTION_SUBJECT_ID: ${{ steps.context.outputs.reaction_subject_id }}
+        with:
+          script: |
+            const run = require(`${process.env.RUNNER_TEMP}/codex-scripts/react.js`);
+            await run({ github, core });
+
   codex:
     if: >
       github.event.sender.type != 'Bot' &&


### PR DESCRIPTION
Adds an acknowledgement reaction for valid Codex slash-command triggers.

The Codex workflow now gives immediate feedback after the initial checks pass. This keeps the reaction separate from the Codex execution path so the model still does not run in a job with comment/reaction write permissions.

- Adds an acknowledge job that reuses the trusted default-branch helper scripts
- Verifies the slash command and repo-writer permission before reacting
- Adds a thumbs-up reaction to issue comments, PR review comments, and submitted PR reviews
- Leaves non-writer triggers without a reaction or Codex run

Validation:

- YAML parse passed
- node --check passed for all Codex helper scripts