### PR TITLE
report codex failures

### DIFF
--- a/.github/scripts/codex/post-feedback.js
+++ b/.github/scripts/codex/post-feedback.js
@@ -1,10 +1,15 @@
 module.exports = async ({ github, context }) => {
   const applyResult = process.env.APPLY_RESULT;
   const patchChanged = process.env.PATCH_CHANGED === "true";
+  const codexOutcome = process.env.CODEX_OUTCOME;
   const changed = process.env.CODEX_CHANGED === "true";
   let body = process.env.CODEX_FINAL_MESSAGE;
 
-  if (patchChanged && applyResult !== "success") {
+  if (codexOutcome && codexOutcome !== "success") {
+    body = `Codex failed before producing a response.
+
+Check the workflow logs for details: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+  } else if (patchChanged && applyResult !== "success") {
     body = `${body}\n\n---\nCodex generated changes, but the workflow could not push them to this PR branch. Check the apply-changes job logs.`;
   } else if (changed) {
     body = `${body}\n\n---\nCodex pushed changes to this PR branch.`;

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -73,6 +73,7 @@ jobs:
       pull-requests: read
     outputs:
       final_message: ${{ steps.run-codex.outputs.final-message }}
+      codex_outcome: ${{ steps.run-codex.outcome }}
       is_valid: ${{ steps.context.outputs.is_valid }}
       can_run: ${{ steps.context.outputs.can_run }}
       can_modify: ${{ steps.context.outputs.can_modify }}
@@ -151,6 +152,7 @@ jobs:
       - name: Run Codex
         if: steps.context.outputs.is_valid == 'true' && steps.context.outputs.can_run == 'true'
         id: run-codex
+        continue-on-error: true
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -160,7 +162,7 @@ jobs:
           safety-strategy: drop-sudo
 
       - name: Capture Codex patch
-        if: steps.context.outputs.is_valid == 'true' && steps.context.outputs.can_run == 'true' && steps.context.outputs.can_modify == 'true'
+        if: steps.context.outputs.is_valid == 'true' && steps.context.outputs.can_run == 'true' && steps.context.outputs.can_modify == 'true' && steps.run-codex.outcome == 'success'
         id: patch
         run: |
           rm -f .codex-prompt.md codex.patch
@@ -182,9 +184,15 @@ jobs:
           path: codex.patch
           if-no-files-found: error
 
+      - name: Mark Codex failure
+        if: steps.run-codex.outcome == 'failure'
+        run: |
+          echo "Codex failed before producing a successful response." >&2
+          exit 1
+
   apply-changes:
     needs: codex
-    if: needs.codex.outputs.is_valid == 'true' && needs.codex.outputs.can_run == 'true'
+    if: needs.codex.outputs.is_valid == 'true' && needs.codex.outputs.can_run == 'true' && needs.codex.outputs.codex_outcome == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -225,7 +233,7 @@ jobs:
 
   post-feedback:
     needs: [codex, apply-changes]
-    if: always() && needs.codex.outputs.is_valid == 'true' && needs.codex.outputs.can_run == 'true' && needs.codex.outputs.final_message != ''
+    if: always() && needs.codex.outputs.is_valid == 'true' && needs.codex.outputs.can_run == 'true' && (needs.codex.outputs.final_message != '' || needs.codex.outputs.codex_outcome != 'success')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -250,6 +258,7 @@ jobs:
           APPLY_RESULT: ${{ needs.apply-changes.result }}
           PATCH_CHANGED: ${{ needs.codex.outputs.patch_changed }}
           CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
+          CODEX_OUTCOME: ${{ needs.codex.outputs.codex_outcome }}
           CODEX_CHANGED: ${{ needs.apply-changes.outputs.changed }}
           REVIEW_COMMENT_ID: ${{ needs.codex.outputs.review_comment_id }}
           TARGET_ISSUE_NUMBER: ${{ needs.codex.outputs.target_issue_number }}


### PR DESCRIPTION
Reports Codex action failures back to the triggering comment or review.

The linked run failed in the Codex step with an OpenAI quota error before Codex produced a final message. Because the workflow only posted feedback when final-message existed, post-feedback was skipped and the user saw no explanation.

- Allows the Codex action step to continue after failure long enough to capture its outcome
- Skips patch capture and apply-changes unless Codex succeeds
- Posts a generic failure message with a workflow run link when Codex fails before producing a response
- Re-fails the codex job after capturing the failure outcome, so Actions still shows the run as failed

Validation:

- YAML parse passed
- node --check passed for Codex helper scripts
- code-review subagent found no issues in the failure path