### PR TITLE
Add Codex issue-to-PR workflow path

### DIFF
--- a/.github/scripts/codex/context.js
+++ b/.github/scripts/codex/context.js
@@ -11,8 +11,10 @@ module.exports = async ({ github, context, core }) => {
   }
 
   const isPullRequestIssueComment = context.eventName === "issue_comment" && !!payload.issue?.pull_request;
+  const isStandaloneIssueComment = context.eventName === "issue_comment" && !!payload.issue && !payload.issue.pull_request;
   const prNumber = payload.pull_request?.number ?? (isPullRequestIssueComment ? payload.issue.number : "");
   const targetIssueNumber = payload.issue?.number ?? prNumber;
+  const baseRef = payload.repository?.default_branch ?? "";
   let actorPermission = "none";
   let canRun = false;
   let canModify = false;
@@ -30,6 +32,7 @@ module.exports = async ({ github, context, core }) => {
     core.warning(`Could not determine ${payload.sender.login}'s repository permission: ${error.message}`);
   }
   canRun = ["admin", "maintain", "write"].includes(actorPermission);
+  const canCreatePr = canRun && isStandaloneIssueComment;
 
   if (prNumber) {
     const { data: pr } = await github.rest.pulls.get({
@@ -48,6 +51,8 @@ module.exports = async ({ github, context, core }) => {
   core.setOutput("actor_permission", actorPermission);
   core.setOutput("can_run", canRun ? "true" : "false");
   core.setOutput("can_modify", canModify ? "true" : "false");
+  core.setOutput("can_create_pr", canCreatePr ? "true" : "false");
+  core.setOutput("base_ref", baseRef);
   core.setOutput("head_ref", headRef);
   core.setOutput("head_repo", headRepo);
   core.setOutput("review_comment_id", context.eventName === "pull_request_review_comment" ? payload.comment.id : "");

--- a/.github/scripts/codex/post-feedback.js
+++ b/.github/scripts/codex/post-feedback.js
@@ -3,6 +3,7 @@ module.exports = async ({ github, context }) => {
   const patchChanged = process.env.PATCH_CHANGED === "true";
   const codexOutcome = process.env.CODEX_OUTCOME;
   const changed = process.env.CODEX_CHANGED === "true";
+  const createdPrUrl = process.env.CREATED_PR_URL || "";
   let body = process.env.CODEX_FINAL_MESSAGE;
 
   if (codexOutcome && codexOutcome !== "success") {
@@ -10,7 +11,9 @@ module.exports = async ({ github, context }) => {
 
 Check the workflow logs for details: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
   } else if (patchChanged && applyResult !== "success") {
-    body = `${body}\n\n---\nCodex generated changes, but the workflow could not push them to this PR branch. Check the apply-changes job logs.`;
+    body = `${body}\n\n---\nCodex generated changes, but the workflow could not apply or publish them. Check the apply-changes job logs.`;
+  } else if (createdPrUrl) {
+    body = `${body}\n\n---\nCodex opened a pull request with these changes: ${createdPrUrl}`;
   } else if (changed) {
     body = `${body}\n\n---\nCodex pushed changes to this PR branch.`;
   }

--- a/.github/scripts/codex/write-prompt.js
+++ b/.github/scripts/codex/write-prompt.js
@@ -10,6 +10,7 @@ module.exports = async ({ github, context, core }) => {
   const repo = context.repo.repo;
   const command = process.env.COMMAND;
   const canModify = process.env.CAN_MODIFY === "true";
+  const canCreatePr = process.env.CAN_CREATE_PR === "true";
   const userPrompt = process.env.USER_PROMPT || "";
   const prNumber = process.env.PR_NUMBER;
   const triggerUrl = process.env.TRIGGER_URL || "";
@@ -56,9 +57,13 @@ Useful commands:
     ? `The commenter has write permission on this repository and this is a same-repository PR branch.
 
 You may modify files in the checked-out PR branch when the requested task calls for code changes. Do not commit, push, create branches, change workflow permissions, or update secrets; the workflow will package any file changes and a separate job will commit them back to the PR branch.`
-    : `The commenter either does not have write permission on this repository, this is not a PR, or this is not a same-repository PR branch.
+    : canCreatePr
+      ? `The commenter has write permission on this repository and invoked Codex from a standalone issue.
 
-You must not modify the PR. Provide feedback only as a GitHub comment or reply.`;
+You may modify files in the checked-out default branch when the requested task calls for code changes. Do not commit, push, create branches, open pull requests, change workflow permissions, or update secrets; the workflow will package any file changes and a separate job will create a branch and pull request.`
+      : `The commenter either does not have write permission on this repository, this is not a PR, or this is not a same-repository PR branch.
+
+You must not modify the PR or repository. Provide feedback only as a GitHub comment or reply.`;
 
   const modePrompt = command === "review"
     ? `You are doing a code review.

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -162,6 +162,10 @@ jobs:
           model: "gpt-5.5"
           # allow-users: "*"
           prompt-file: ${{ steps.prompt.outputs.prompt_file }}
+          # Ignore the repository-local Codex config in CI: this dotfiles repo
+          # contains personal machine config that references local-only paths.
+          codex-args: >-
+            ["--config", "projects.\"/home/runner/work/dotfiles/dotfiles\".trust_level=\"untrusted\""]
           sandbox: ${{ (steps.context.outputs.can_modify == 'true' || steps.context.outputs.can_create_pr == 'true') && 'workspace-write' || 'read-only' }}
           safety-strategy: drop-sudo
 

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -77,6 +77,8 @@ jobs:
       is_valid: ${{ steps.context.outputs.is_valid }}
       can_run: ${{ steps.context.outputs.can_run }}
       can_modify: ${{ steps.context.outputs.can_modify }}
+      can_create_pr: ${{ steps.context.outputs.can_create_pr }}
+      base_ref: ${{ steps.context.outputs.base_ref || steps.prompt.outputs.base_ref }}
       patch_changed: ${{ steps.patch.outputs.changed }}
       head_ref: ${{ steps.context.outputs.head_ref }}
       review_comment_id: ${{ steps.context.outputs.review_comment_id }}
@@ -133,6 +135,7 @@ jobs:
         env:
           COMMAND: ${{ steps.context.outputs.command }}
           CAN_MODIFY: ${{ steps.context.outputs.can_modify }}
+          CAN_CREATE_PR: ${{ steps.context.outputs.can_create_pr }}
           USER_PROMPT: ${{ steps.context.outputs.user_prompt }}
           PR_NUMBER: ${{ steps.context.outputs.pr_number }}
           TRIGGER_URL: ${{ steps.context.outputs.trigger_url }}
@@ -159,11 +162,11 @@ jobs:
           model: "gpt-5.5"
           # allow-users: "*"
           prompt-file: ${{ steps.prompt.outputs.prompt_file }}
-          sandbox: ${{ steps.context.outputs.can_modify == 'true' && 'workspace-write' || 'read-only' }}
+          sandbox: ${{ (steps.context.outputs.can_modify == 'true' || steps.context.outputs.can_create_pr == 'true') && 'workspace-write' || 'read-only' }}
           safety-strategy: drop-sudo
 
       - name: Capture Codex patch
-        if: steps.context.outputs.is_valid == 'true' && steps.context.outputs.can_run == 'true' && steps.context.outputs.can_modify == 'true' && steps.run-codex.outcome == 'success'
+        if: steps.context.outputs.is_valid == 'true' && steps.context.outputs.can_run == 'true' && (steps.context.outputs.can_modify == 'true' || steps.context.outputs.can_create_pr == 'true') && steps.run-codex.outcome == 'success'
         id: patch
         run: |
           rm -f .codex-prompt.md codex.patch
@@ -197,8 +200,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     outputs:
-      changed: ${{ steps.commit.outputs.changed || 'false' }}
+      changed: ${{ steps.commit-existing.outputs.changed || steps.commit-pr.outputs.changed || 'false' }}
+      pr_url: ${{ steps.commit-pr.outputs.pr_url }}
     steps:
       - name: Checkout PR branch
         if: needs.codex.outputs.can_modify == 'true' && needs.codex.outputs.patch_changed == 'true'
@@ -207,15 +212,22 @@ jobs:
           ref: ${{ needs.codex.outputs.head_ref }}
           fetch-depth: 1
 
+      - name: Checkout base branch
+        if: needs.codex.outputs.can_create_pr == 'true' && needs.codex.outputs.patch_changed == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.codex.outputs.base_ref }}
+          fetch-depth: 1
+
       - name: Download Codex patch
-        if: needs.codex.outputs.can_modify == 'true' && needs.codex.outputs.patch_changed == 'true'
+        if: (needs.codex.outputs.can_modify == 'true' || needs.codex.outputs.can_create_pr == 'true') && needs.codex.outputs.patch_changed == 'true'
         uses: actions/download-artifact@v4
         with:
           name: codex-patch
 
       - name: Apply and push Codex changes
         if: needs.codex.outputs.can_modify == 'true' && needs.codex.outputs.patch_changed == 'true'
-        id: commit
+        id: commit-existing
         env:
           HEAD_REF: ${{ needs.codex.outputs.head_ref }}
         run: |
@@ -231,6 +243,37 @@ jobs:
           git commit -m "apply codex changes"
           git push origin "HEAD:$HEAD_REF"
           echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Apply changes and open PR
+        if: needs.codex.outputs.can_create_pr == 'true' && needs.codex.outputs.patch_changed == 'true'
+        id: commit-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ needs.codex.outputs.target_issue_number }}
+          BASE_REF: ${{ needs.codex.outputs.base_ref }}
+          BRANCH: codex/issue-${{ needs.codex.outputs.target_issue_number }}-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          git switch -c "$BRANCH"
+          git apply --index codex.patch
+
+          if git diff --cached --quiet --exit-code; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "apply codex changes"
+          git push origin "HEAD:$BRANCH"
+
+          pr_url=$(gh pr create \
+            --base "$BASE_REF" \
+            --head "$BRANCH" \
+            --title "Codex changes for #$ISSUE_NUMBER" \
+            --body "Generated from #$ISSUE_NUMBER.")
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
 
   post-feedback:
     needs: [codex, apply-changes]
@@ -261,6 +304,7 @@ jobs:
           CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
           CODEX_OUTCOME: ${{ needs.codex.outputs.codex_outcome }}
           CODEX_CHANGED: ${{ needs.apply-changes.outputs.changed }}
+          CREATED_PR_URL: ${{ needs.apply-changes.outputs.pr_url }}
           REVIEW_COMMENT_ID: ${{ needs.codex.outputs.review_comment_id }}
           TARGET_ISSUE_NUMBER: ${{ needs.codex.outputs.target_issue_number }}
         with:


### PR DESCRIPTION
Implements the Codex workflow changes requested in #90.

- Allows trusted standalone issue comments to run Codex in workspace-write mode.
- Captures patches from issue-triggered runs.
- Adds an apply path that creates a branch and opens a PR.
- Updates feedback to report the created PR URL.