### PR TITLE
Make Codex model catalog portable

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.5"
 model_provider = "cloudflare-ai-gateway"
-model_catalog_json = "/Users/matt/.codex/model-catalogs/cloudflare-ai-gateway.json"
+model_catalog_json = "./model-catalogs/cloudflare-ai-gateway.json"
 model_context_window = 200000
 
 # Default permissions translated from .config/opencode/opencode.jsonc.

--- a/.codex/model-catalogs/cloudflare-ai-gateway.json
+++ b/.codex/model-catalogs/cloudflare-ai-gateway.json
@@ -1,0 +1,148 @@
+{
+  "models": [
+    {
+      "slug": "gpt-5.5",
+      "display_name": "GPT-5.5",
+      "description": "GPT-5.5 via Cloudflare AI Gateway.",
+      "default_reasoning_level": "medium",
+      "supported_reasoning_levels": [
+        { "effort": "low", "description": "Fast responses with lighter reasoning" },
+        { "effort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+        { "effort": "high", "description": "Greater reasoning depth for complex problems" },
+        { "effort": "xhigh", "description": "Extra high reasoning depth for complex problems" }
+      ],
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 0,
+      "additional_speed_tiers": ["fast"],
+      "service_tiers": [
+        { "id": "priority", "name": "Fast", "description": "Faster processing using the priority service tier" }
+      ],
+      "base_instructions": "You are Codex, a coding agent based on GPT-5.",
+      "truncation_policy": { "mode": "tokens", "limit": 10000 },
+      "supports_reasoning_summaries": true,
+      "default_reasoning_summary": "none",
+      "support_verbosity": true,
+      "default_verbosity": "low",
+      "apply_patch_tool_type": "freeform",
+      "web_search_tool_type": "text_and_image",
+      "supports_parallel_tool_calls": true,
+      "supports_image_detail_original": true,
+      "context_window": 200000,
+      "max_context_window": 200000,
+      "effective_context_window_percent": 95,
+      "experimental_supported_tools": [],
+      "input_modalities": ["text", "image"],
+      "supports_search_tool": true
+    },
+    {
+      "slug": "gpt-5.4",
+      "display_name": "GPT-5.4",
+      "description": "Strong model for everyday coding via Cloudflare AI Gateway.",
+      "default_reasoning_level": "medium",
+      "supported_reasoning_levels": [
+        { "effort": "low", "description": "Fast responses with lighter reasoning" },
+        { "effort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+        { "effort": "high", "description": "Greater reasoning depth for complex problems" },
+        { "effort": "xhigh", "description": "Extra high reasoning depth for complex problems" }
+      ],
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 1,
+      "additional_speed_tiers": ["fast"],
+      "service_tiers": [
+        { "id": "priority", "name": "Fast", "description": "Faster processing using the priority service tier" }
+      ],
+      "base_instructions": "You are Codex, a coding agent based on GPT-5.",
+      "truncation_policy": { "mode": "tokens", "limit": 10000 },
+      "supports_reasoning_summaries": true,
+      "default_reasoning_summary": "none",
+      "support_verbosity": true,
+      "default_verbosity": "low",
+      "apply_patch_tool_type": "freeform",
+      "web_search_tool_type": "text_and_image",
+      "supports_parallel_tool_calls": true,
+      "supports_image_detail_original": true,
+      "context_window": 200000,
+      "max_context_window": 1000000,
+      "effective_context_window_percent": 95,
+      "experimental_supported_tools": [],
+      "input_modalities": ["text", "image"],
+      "supports_search_tool": true
+    },
+    {
+      "slug": "gpt-5.4-mini",
+      "display_name": "GPT-5.4 Mini",
+      "description": "Small, fast, and cost-efficient model for simpler coding tasks via Cloudflare AI Gateway.",
+      "default_reasoning_level": "medium",
+      "supported_reasoning_levels": [
+        { "effort": "low", "description": "Fast responses with lighter reasoning" },
+        { "effort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+        { "effort": "high", "description": "Greater reasoning depth for complex problems" },
+        { "effort": "xhigh", "description": "Extra high reasoning depth for complex problems" }
+      ],
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 2,
+      "additional_speed_tiers": ["fast"],
+      "service_tiers": [
+        { "id": "priority", "name": "Fast", "description": "Faster processing using the priority service tier" }
+      ],
+      "base_instructions": "You are Codex, a coding agent based on GPT-5.",
+      "truncation_policy": { "mode": "tokens", "limit": 10000 },
+      "supports_reasoning_summaries": true,
+      "default_reasoning_summary": "none",
+      "support_verbosity": true,
+      "default_verbosity": "medium",
+      "apply_patch_tool_type": "freeform",
+      "web_search_tool_type": "text_and_image",
+      "supports_parallel_tool_calls": true,
+      "supports_image_detail_original": true,
+      "context_window": 200000,
+      "max_context_window": 200000,
+      "effective_context_window_percent": 95,
+      "experimental_supported_tools": [],
+      "input_modalities": ["text", "image"],
+      "supports_search_tool": true
+    },
+    {
+      "slug": "gpt-5.4-nano",
+      "display_name": "GPT-5.4 Nano",
+      "description": "Smallest GPT-5.4 model for lightweight coding tasks via Cloudflare AI Gateway.",
+      "default_reasoning_level": "medium",
+      "supported_reasoning_levels": [
+        { "effort": "low", "description": "Fast responses with lighter reasoning" },
+        { "effort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+        { "effort": "high", "description": "Greater reasoning depth for complex problems" },
+        { "effort": "xhigh", "description": "Extra high reasoning depth for complex problems" }
+      ],
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 3,
+      "additional_speed_tiers": ["fast"],
+      "service_tiers": [
+        { "id": "priority", "name": "Fast", "description": "Faster processing using the priority service tier" }
+      ],
+      "base_instructions": "You are Codex, a coding agent based on GPT-5.",
+      "truncation_policy": { "mode": "tokens", "limit": 10000 },
+      "supports_reasoning_summaries": true,
+      "default_reasoning_summary": "none",
+      "support_verbosity": true,
+      "default_verbosity": "medium",
+      "apply_patch_tool_type": "freeform",
+      "web_search_tool_type": "text_and_image",
+      "supports_parallel_tool_calls": true,
+      "supports_image_detail_original": true,
+      "context_window": 200000,
+      "max_context_window": 200000,
+      "effective_context_window_percent": 95,
+      "experimental_supported_tools": [],
+      "input_modalities": ["text", "image"],
+      "supports_search_tool": false
+    }
+  ]
+}

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -162,10 +162,6 @@ jobs:
           model: "gpt-5.5"
           # allow-users: "*"
           prompt-file: ${{ steps.prompt.outputs.prompt_file }}
-          # Ignore the repository-local Codex config in CI: this dotfiles repo
-          # contains personal machine config that references local-only paths.
-          codex-args: >-
-            ["--config", "projects.\"/home/runner/work/dotfiles/dotfiles\".trust_level=\"untrusted\""]
           sandbox: ${{ (steps.context.outputs.can_modify == 'true' || steps.context.outputs.can_create_pr == 'true') && 'workspace-write' || 'read-only' }}
           safety-strategy: drop-sudo
 


### PR DESCRIPTION
Fixes the Codex Action startup failure after #91.

The action was still loading the repository project config, which referenced a machine-local model catalog path under `/Users/matt`. This commits that model catalog into the repo and changes `model_catalog_json` to a relative path resolved from `.codex/`.

Also removes the ineffective `codex-args` trust-level workaround from the workflow so CI relies on a portable project config instead.