### PR TITLE
Handle Codex failures

### DIFF
--- a/.github/scripts/codex/post-feedback.js
+++ b/.github/scripts/codex/post-feedback.js
@@ -1,21 +1,38 @@
 module.exports = async ({ github, context }) => {
   const applyResult = process.env.APPLY_RESULT;
   const patchChanged = process.env.PATCH_CHANGED === "true";
+  const patchBlocked = process.env.PATCH_BLOCKED === "true";
+  const patchBlockedPaths = process.env.PATCH_BLOCKED_PATHS || "";
   const codexOutcome = process.env.CODEX_OUTCOME;
   const changed = process.env.CODEX_CHANGED === "true";
   const createdPrUrl = process.env.CREATED_PR_URL || "";
-  let body = process.env.CODEX_FINAL_MESSAGE;
+  let body = process.env.CODEX_FINAL_MESSAGE || "Codex completed without a final message.";
+
+  const appendStatus = (message) => {
+    body = `${body}\n\n---\n${message}`;
+  };
 
   if (codexOutcome && codexOutcome !== "success") {
     body = `Codex failed before producing a response.
 
 Check the workflow logs for details: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+  } else if (patchBlocked) {
+    appendStatus(`Codex changed blocked paths, so no patch or PR was published.
+
+Blocked paths:
+${patchBlockedPaths}
+
+A maintainer should review these changes manually before applying them.`);
   } else if (patchChanged && applyResult !== "success") {
-    body = `${body}\n\n---\nCodex generated changes, but the workflow could not apply or publish them. Check the apply-changes job logs.`;
+    appendStatus("Codex generated changes, but the workflow could not apply or publish them. No PR was opened. Check the apply-changes job logs.");
   } else if (createdPrUrl) {
-    body = `${body}\n\n---\nCodex opened a pull request with these changes: ${createdPrUrl}`;
+    appendStatus(`Codex opened a pull request with these changes: ${createdPrUrl}`);
   } else if (changed) {
-    body = `${body}\n\n---\nCodex pushed changes to this PR branch.`;
+    appendStatus("Codex pushed changes to this PR branch.");
+  } else if (patchChanged) {
+    appendStatus("Codex generated changes, but the apply job did not report a pushed branch or PR URL. No PR was opened. Check the apply-changes job logs.");
+  } else {
+    appendStatus("Codex did not capture file changes, so no PR was opened.");
   }
 
   const reviewCommentId = process.env.REVIEW_COMMENT_ID;

--- a/.github/scripts/codex/react.js
+++ b/.github/scripts/codex/react.js
@@ -1,20 +1,63 @@
+const REACTIONS = new Set([
+  "THUMBS_UP",
+  "THUMBS_DOWN",
+  "LAUGH",
+  "HOORAY",
+  "CONFUSED",
+  "HEART",
+  "ROCKET",
+  "EYES",
+]);
+
+const reactionContent = (value, fallback = "") => {
+  const content = value || fallback;
+  if (!content) {
+    return "";
+  }
+  if (!REACTIONS.has(content)) {
+    throw new Error(`Unsupported reaction content: ${content}`);
+  }
+  return content;
+};
+
 module.exports = async ({ github, core }) => {
   const subjectId = process.env.REACTION_SUBJECT_ID;
   if (!subjectId) {
     return;
   }
 
-  try {
-    await github.graphql(`
-      mutation AddReaction($subjectId: ID!) {
-        addReaction(input: { subjectId: $subjectId, content: THUMBS_UP }) {
-          reaction {
-            content
+  const removeContent = reactionContent(process.env.REMOVE_REACTION_CONTENT);
+  const addContent = reactionContent(process.env.ADD_REACTION_CONTENT, "THUMBS_UP");
+
+  if (removeContent) {
+    try {
+      await github.graphql(`
+        mutation RemoveReaction($subjectId: ID!, $content: ReactionContent!) {
+          removeReaction(input: { subjectId: $subjectId, content: $content }) {
+            subject {
+              id
+            }
           }
         }
-      }
-    `, { subjectId });
-  } catch (error) {
-    core.warning(`Could not add thumbs-up reaction: ${error.message}`);
+      `, { subjectId, content: removeContent });
+    } catch (error) {
+      core.warning(`Could not remove ${removeContent} reaction: ${error.message}`);
+    }
+  }
+
+  if (addContent) {
+    try {
+      await github.graphql(`
+        mutation AddReaction($subjectId: ID!, $content: ReactionContent!) {
+          addReaction(input: { subjectId: $subjectId, content: $content }) {
+            reaction {
+              content
+            }
+          }
+        }
+      `, { subjectId, content: addContent });
+    } catch (error) {
+      core.warning(`Could not add ${addContent} reaction: ${error.message}`);
+    }
   }
 };

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -80,8 +80,11 @@ jobs:
       can_create_pr: ${{ steps.context.outputs.can_create_pr }}
       base_ref: ${{ steps.context.outputs.base_ref || steps.prompt.outputs.base_ref }}
       patch_changed: ${{ steps.patch.outputs.changed }}
+      patch_blocked: ${{ steps.patch.outputs.blocked }}
+      patch_blocked_paths: ${{ steps.patch.outputs.blocked_paths }}
       head_ref: ${{ steps.context.outputs.head_ref }}
       review_comment_id: ${{ steps.context.outputs.review_comment_id }}
+      reaction_subject_id: ${{ steps.context.outputs.reaction_subject_id }}
       target_issue_number: ${{ steps.context.outputs.target_issue_number }}
     steps:
       - name: Checkout workflow scripts
@@ -171,6 +174,33 @@ jobs:
         run: |
           rm -f .codex-prompt.md codex.patch
           git add -A .
+
+          blocked_paths=()
+          while IFS= read -r -d '' path; do
+            lower_path=$(printf '%s' "$path" | tr '[:upper:]' '[:lower:]')
+            case "$lower_path" in
+              .github/workflows/*|.github/scripts/codex/*|.env|.env.*|*/.env|*/.env.*|*.pem|*.key|*.p12|*.pfx)
+                safe_path=${path//$'\r'/\\r}
+                safe_path=${safe_path//$'\n'/\\n}
+                blocked_paths+=("$safe_path")
+                ;;
+            esac
+          done < <(git diff --cached --name-only -z)
+
+          if ((${#blocked_paths[@]})); then
+            {
+              echo "changed=false"
+              echo "blocked=true"
+              echo "blocked_paths<<EOF"
+              printf '%s\n' "${blocked_paths[@]}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+
+            printf '::error::Codex changed blocked path: %s\n' "${blocked_paths[@]}" >&2
+            exit 0
+          fi
+
+          echo "blocked=false" >> "$GITHUB_OUTPUT"
 
           if git diff --cached --quiet --exit-code; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -276,8 +306,8 @@ jobs:
           echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
 
   post-feedback:
-    needs: [codex, apply-changes]
-    if: always() && needs.codex.outputs.is_valid == 'true' && needs.codex.outputs.can_run == 'true' && (needs.codex.outputs.final_message != '' || needs.codex.outputs.codex_outcome != 'success')
+    needs: [acknowledge, codex, apply-changes]
+    if: always() && needs.codex.outputs.is_valid == 'true' && needs.codex.outputs.can_run == 'true' && (needs.codex.outputs.final_message != '' || needs.codex.outputs.codex_outcome != 'success' || needs.codex.outputs.patch_changed == 'true' || needs.codex.outputs.patch_blocked == 'true')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -296,11 +326,25 @@ jobs:
           mkdir -p "$RUNNER_TEMP/codex-scripts"
           cp .github/scripts/codex/*.js "$RUNNER_TEMP/codex-scripts/"
 
+      - name: React to failure
+        if: needs.codex.outputs.codex_outcome != 'success' || needs.codex.outputs.patch_blocked == 'true' || (needs.codex.outputs.patch_changed == 'true' && needs.apply-changes.result != 'success') || (needs.codex.outputs.patch_changed == 'true' && needs.codex.outputs.can_create_pr == 'true' && needs.apply-changes.outputs.pr_url == '')
+        uses: actions/github-script@v7
+        env:
+          REACTION_SUBJECT_ID: ${{ needs.codex.outputs.reaction_subject_id }}
+          REMOVE_REACTION_CONTENT: THUMBS_UP
+          ADD_REACTION_CONTENT: THUMBS_DOWN
+        with:
+          script: |
+            const run = require(`${process.env.RUNNER_TEMP}/codex-scripts/react.js`);
+            await run({ github, core });
+
       - name: Post Codex feedback
         uses: actions/github-script@v7
         env:
           APPLY_RESULT: ${{ needs.apply-changes.result }}
           PATCH_CHANGED: ${{ needs.codex.outputs.patch_changed }}
+          PATCH_BLOCKED: ${{ needs.codex.outputs.patch_blocked }}
+          PATCH_BLOCKED_PATHS: ${{ needs.codex.outputs.patch_blocked_paths }}
           CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
           CODEX_OUTCOME: ${{ needs.codex.outputs.codex_outcome }}
           CODEX_CHANGED: ${{ needs.apply-changes.outputs.changed }}


### PR DESCRIPTION
Handles Codex failure and no-PR feedback paths for #94.

The Codex workflow could acknowledge a slash command with thumbs-up, then fail or report generated changes without producing a PR. Patch capture also staged every workspace change, which made workflow/script and secret-like file changes publishable without an explicit gate.

- Replace the initial thumbs-up with thumbs-down for hard failures, blocked patches, apply failures, and missing PR URLs after captured changes.
- Make feedback explicitly say whether a PR was opened, a branch was pushed, changes could not be published, no changes were captured, or paths were blocked.
- Block publication of Codex-generated workflow/script changes, dotenv files, and key/certificate-like files before creating `codex.patch`.

Validation:
- `node --check` for all Codex scripts
- YAML parse check for `.github/workflows/codex.yml`
- `actionlint .github/workflows/codex.yml`
- `git diff --check` for the Codex files
- mocked hard-failure reaction flow
- denylist and newline sanitization simulations
- final focused code review found no confirmed issues

Fixes #94.