### PR TITLE
Clean up Codex config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -12,8 +12,6 @@ notify = ["/Users/matt/.codex/computer-use/Codex Computer Use.app/Contents/Share
 
 [features]
 enable_request_compression = false
-terminal_resize_reflow = true
-js_repl = false
 
 [model_providers.cloudflare-ai-gateway]
 name = "OpenAI: Cloudflare AI Gateway"
@@ -117,6 +115,7 @@ enabled = true
 [plugins."presentations@openai-primary-runtime"]
 enabled = true
 
+# macOS Codex app Browser Use bridge. Expected to warn under Linux.
 [mcp_servers.node_repl]
 args = []
 command = "/Applications/Codex.app/Contents/Resources/cua_node/bin/node_repl"

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -1,4 +1,1 @@
 prefix_rule(pattern=["gh", "pr", "list"], decision="allow")
-prefix_rule(pattern=["gh", "api", "graphql"], decision="allow")
-prefix_rule(pattern=["jq", "-r", ".data.repository.pullRequests.nodes[] | select([.files.nodes[].path] | any(test(\"(^|/)kv(/|$)|workers-kv|key-value\"; \"i\"))) | {number,title,url,isDraft,updatedAt,reviewDecision,mergeStateStatus,labels:[.labels.nodes[].name],files:[.files.nodes[].path | select(test(\"(^|/)kv(/|$)|workers-kv|key-value\"; \"i\"))]} | @json"], decision="allow")
-prefix_rule(pattern=["rm", "-rf", "/tmp/afs-pr10-test"], decision="allow")


### PR DESCRIPTION
Applies the Codex config audit findings from #96.

Codex could not edit `.codex/` from the Actions sandbox because that directory is treated as Codex config/rules state and mounted read-only. Applying the suggested cleanup outside that sandbox avoids weakening the workflow sandbox just to edit config files.

- Remove obsolete explicit feature overrides from `.codex/config.toml`.
- Remove broad and one-off durable allow rules, leaving only the narrow `gh pr list` allow.
- Document that the Browser Use `node_repl` MCP entry is a macOS Codex app bridge and is expected to warn under Linux.

Validation:
- `CODEX_HOME=$PWD/.codex codex doctor`
- parsed `.codex/model-catalogs/cloudflare-ai-gateway.json` with Ruby JSON
- confirmed removed feature/rule patterns no longer appear under `.codex/`
- `git diff --check` for changed files

Fixes #96.