### PR TITLE
add WorkbenchOS MCP server

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -210,6 +210,10 @@ url = "https://mcp.cloudflare.com/mcp"
 [mcp_servers."cloudflare-docs"]
 url = "https://docs.mcp.cloudflare.com/mcp"
 
+# Public, stateless WorkbenchOS Motronic ROM/XDF tools.
+[mcp_servers.workbenchos]
+url = "https://workbench.questionable.services/mcp"
+
 [mcp_servers."google-workspace"]
 url = "https://google-workspace-mcp.cto.cfdata.org/mcp"
 enabled = false


### PR DESCRIPTION
## Summary

- register the public WorkbenchOS MCP endpoint in the shared Codex configuration
- use the unauthenticated Streamable HTTP endpoint at `https://workbench.questionable.services/mcp`

## Why

This makes the WorkbenchOS Motronic ROM/XDF validation, decoding, diffing, fueling-comparison, and calibration-edit tools available to the Codex desktop app, CLI, and IDE extension once the WorkbenchOS endpoint is merged and public.

No credentials or environment variables are required.

## Validation

- parsed the added TOML server table with Python `tomllib`
- reviewed the branch diff: one configuration file, four added lines