### PR TITLE
refresh terminal and editor configs

### DIFF
--- a/.config/ghostty/config.ghostty
+++ b/.config/ghostty/config.ghostty
@@ -1,6 +1,7 @@
 # github.com/elithrar/dotfiles
 
 theme = orng-dark
+minimum-contrast = 1.1
 font-size = 15
 font-family = "TX-02"
 
@@ -31,8 +32,14 @@ mouse-hide-while-typing = true
 mouse-shift-capture = never
 cursor-style-blink = false
 
-# Enable all shell integration features including SSH env/terminfo (1.2.0)
-shell-integration-features = cursor,sudo,title,ssh-env,ssh-terminfo
+# Enable all shell integration features, including SSH support and PATH setup.
+shell-integration-features = true
+
+# Notify after long-running commands finish while an integrated shell is unfocused.
+# tmux consumes raw OSC 133 markers, so this applies to direct Ghostty shells.
+notify-on-command-finish = unfocused
+notify-on-command-finish-action = no-bell,notify
+notify-on-command-finish-after = 30s
 
 link-url = true
 link-previews = osc8
@@ -56,5 +63,3 @@ keybind = cmd+shift+l=copy_url_to_clipboard
 # Jump between shell prompts (requires shell integration)
 keybind = shift+up=jump_to_prompt:-1
 keybind = shift+down=jump_to_prompt:1
-
-command-palette-entry = title:vim mode,action:activate_key_table:vim

--- a/.config/zed/settings.json
+++ b/.config/zed/settings.json
@@ -1,14 +1,4 @@
 {
-  "agent_servers": {
-    "opencode": {
-      "type": "extension",
-      "favorite_models": [
-        "anthropic/claude-opus-4-5-20251101"
-      ],
-      "default_config_options": {},
-      "favorite_config_option_values": {}
-    }
-  },
   "agent_font_size": 15,
   "icon_theme": "Zed (Default)",
   "edit_predictions": {
@@ -79,33 +69,6 @@
     "inline_assistant_model": {
       "provider": "anthropic",
       "model": "claude-sonnet-4-5-latest"
-    },
-    "profiles": {
-      "write": {
-        "name": "Write",
-        "tools": {
-          "terminal": true,
-          "batch_tool": true,
-          "code_symbols": true,
-          "copy_path": true,
-          "create_file": true,
-          "delete_path": true,
-          "diagnostics": true,
-          "edit_file": true,
-          "edit_files": false,
-          "fetch": true,
-          "list_directory": true,
-          "move_path": true,
-          "now": true,
-          "find_path": true,
-          "read_file": true,
-          "grep": true,
-          "symbol_info": true,
-          "thinking": true
-        },
-        "enable_all_context_servers": true,
-        "context_servers": {}
-      }
     },
     "dock": "right",
     "enabled": true,

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -16,9 +16,9 @@ set -g extended-keys-format csi-u
 # Prevents resizing unless the smaller screen is active
 setw -g aggressive-resize on
 
-# Allow interaction with system clipboard
-# Modern tmux (3.2+) has native macOS clipboard support
-set -g set-clipboard on
+# Let tmux copy through the terminal while blocking applications from setting
+# the host clipboard directly.
+set -g set-clipboard external
 
 # Index starts at '1' and not '0'
 set -g base-index 1
@@ -44,10 +44,6 @@ bind -r H resize-pane -L 5
 bind -r J resize-pane -D 5
 bind -r K resize-pane -U 5
 bind -r L resize-pane -R 5
-
-# Check activity in other windows
-setw -g monitor-activity off
-set -g visual-activity on
 
 # Window titles
 set -g set-titles on
@@ -93,7 +89,7 @@ unbind p
 bind Escape copy-mode
 bind p paste-buffer
 bind-key -T copy-mode-vi v send-keys -X begin-selection
-bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
+bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 unbind -T copy-mode-vi Enter
 bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
 bind -T copy-mode-vi Escape send-keys -X cancel
@@ -104,6 +100,3 @@ set -as terminal-features ",xterm-ghostty:RGB,*256col*:RGB"
 
 # Enable focus events for better vim/neovim integration
 set -g focus-events on
-
-# Force tmux to use the default shell
-set-option -g default-shell $SHELL


### PR DESCRIPTION
Refresh the Zed, Ghostty, and tmux configs for their current option sets.

Zed still overrode its Write profile with retired tool names and registered OpenCode through the deprecated extension path. Ghostty included an action for a missing vim key table, while tmux used a macOS-specific clipboard subprocess and contradictory activity settings.

- Inherit Zed’s current built-in Write profile and use the already-installed OpenCode ACP registry agent
- Remove the no-op Ghostty key-table action, enable all current shell features, add a contrast floor, and notify after long direct-shell commands
- Rename the Ghostty config to the current config.ghostty convention without changing the explicit dark palette
- Use tmux OSC 52 clipboard output with external-only access and remove stale activity and shell defaults

Validation:

- Parsed Zed settings with jq and confirmed the current app log has no settings errors
- Loaded the renamed Ghostty config with show-config and verified the selected options expand correctly
- Loaded tmux 3.7b in an isolated server and verified the copy-mode binding and option state
- Captured an attached tmux PTY and confirmed the exact OSC 52 clipboard payload was emitted