### PR TITLE
Add USGC themes for Ghostty and Codex

### DIFF
--- a/.codex/themes/usgc.tmTheme
+++ b/.codex/themes/usgc.tmTheme
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>usgc</string>
+  <key>author</key>
+  <string>U.S. Graphics Company; adapted for Codex TUI</string>
+  <key>semanticClass</key>
+  <string>theme.dark.usgc</string>
+  <key>uuid</key>
+  <string>83C21B1F-4D06-5B8F-BD4C-52F2F63B8A11</string>
+  <key>colorSpaceName</key>
+  <string>sRGB</string>
+  <key>settings</key>
+  <array>
+    <dict>
+      <key>settings</key>
+      <dict>
+        <key>background</key>
+        <string>#000000</string>
+        <key>foreground</key>
+        <string>#459A65</string>
+        <key>caret</key>
+        <string>#868D96</string>
+        <key>selection</key>
+        <string>#01057C</string>
+        <key>lineHighlight</key>
+        <string>#262626</string>
+        <key>inactiveSelection</key>
+        <string>#26265C</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Comments</string>
+      <key>scope</key>
+      <string>comment, punctuation.definition.comment, comment.block.documentation, comment.line.documentation</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#75767C</string><key>fontStyle</key><string>italic</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Keywords</string>
+      <key>scope</key>
+      <string>keyword, storage, storage.type, storage.modifier, punctuation.definition.keyword</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#CD0400</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Operators</string>
+      <key>scope</key>
+      <string>keyword.operator, keyword.operator.expression, punctuation.separator, punctuation.accessor</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#3376F6</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Strings</string>
+      <key>scope</key>
+      <string>string, string.quoted, string.template, meta.string</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#F6C443</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>String escapes and regex</string>
+      <key>scope</key>
+      <string>constant.character.escape, string.regexp, string.special, punctuation.definition.template-expression</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#EE7B3B</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Numbers, constants, booleans</string>
+      <key>scope</key>
+      <string>constant.numeric, constant.language, constant.other, variable.other.constant</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#EA3D8D</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Functions and methods</string>
+      <key>scope</key>
+      <string>entity.name.function, support.function, meta.function-call, variable.function</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#EE7B3B</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Classes, constructors, variants</string>
+      <key>scope</key>
+      <string>entity.name.type, entity.name.class, entity.name.struct, entity.name.enum, entity.name.union, support.class, support.type, variable.other.enummember</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#6B40EF</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Variables and parameters</string>
+      <key>scope</key>
+      <string>variable, variable.parameter, meta.parameter, meta.definition.variable</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#459A65</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Properties and fields</string>
+      <key>scope</key>
+      <string>variable.other.property, variable.other.member, support.variable.property, meta.object-literal.key</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#3376F6</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Tags</string>
+      <key>scope</key>
+      <string>entity.name.tag, punctuation.definition.tag</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#CD0400</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Attributes</string>
+      <key>scope</key>
+      <string>entity.other.attribute-name, support.type.property-name, meta.attribute</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#EA3D8D</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Headings and titles</string>
+      <key>scope</key>
+      <string>markup.heading, entity.name.section, markup.heading punctuation.definition.heading</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#F6C443</string><key>fontStyle</key><string>bold</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Bold</string>
+      <key>scope</key>
+      <string>markup.bold, punctuation.definition.bold</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#FEFEFF</string><key>fontStyle</key><string>bold</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Italic</string>
+      <key>scope</key>
+      <string>markup.italic, punctuation.definition.italic</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#EBBC40</string><key>fontStyle</key><string>italic</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Links</string>
+      <key>scope</key>
+      <string>markup.underline.link, meta.link.inline, string.other.link, markup.link</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#489FB2</string><key>fontStyle</key><string>underline</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Inline code and code fences</string>
+      <key>scope</key>
+      <string>markup.raw, markup.raw.inline, markup.fenced_code.block</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#F6C443</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Quotes</string>
+      <key>scope</key>
+      <string>markup.quote, punctuation.definition.quote</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#459A65</string><key>fontStyle</key><string>italic</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Inserted diff</string>
+      <key>scope</key>
+      <string>markup.inserted, markup.inserted.diff, diff.inserted, meta.diff.header.to-file</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#459A65</string><key>background</key><string>#0A2416</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Deleted diff</string>
+      <key>scope</key>
+      <string>markup.deleted, markup.deleted.diff, diff.deleted, meta.diff.header.from-file</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#CD0400</string><key>background</key><string>#2D0A08</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Changed diff</string>
+      <key>scope</key>
+      <string>markup.changed, meta.diff.range</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#F6C443</string></dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Invalid</string>
+      <key>scope</key>
+      <string>invalid, invalid.illegal</string>
+      <key>settings</key>
+      <dict><key>foreground</key><string>#FEFB52</string><key>background</key><string>#CD0400</string></dict>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/.config/ghostty/themes/usgc
+++ b/.config/ghostty/themes/usgc
@@ -1,0 +1,32 @@
+# USGC RETICLE - Ghostty Theme
+# Adapted from USGC-RETICLE-IT by U.S. Graphics Company.
+# Values preserve the source Display P3 components; use with
+# window-colorspace = display-p3 for a faithful match.
+
+background = #000000
+foreground = #459A65
+cursor-color = #868D96
+cursor-text = #FFFFFF
+selection-background = #01057C
+selection-foreground = #F6C443
+bold-color = #75767C
+
+# Standard colors (0-7)
+palette = 0=#262626
+palette = 1=#CD0400
+palette = 2=#F6C443
+palette = 3=#F6C443
+palette = 4=#6B40EF
+palette = 5=#EA3D8D
+palette = 6=#3477F6
+palette = 7=#FFFFFF
+
+# Bright colors (8-15)
+palette = 8=#484747
+palette = 9=#CD0400
+palette = 10=#EBBC40
+palette = 11=#F6C443
+palette = 12=#EE7B3B
+palette = 13=#EA3D8D
+palette = 14=#3376F6
+palette = 15=#FEFEFF


### PR DESCRIPTION
## What changed

- Add `.config/ghostty/themes/usgc`, converted from the USGC RETICLE iTerm theme.
- Add `.codex/themes/usgc.tmTheme`, mapping the same palette to Codex syntax and diff scopes.
- Leave the active `orng` selections unchanged so the themes can be previewed before switching.

## Why

Make the USGC RETICLE palette available by name in both Ghostty and the Codex TUI. The Ghostty values preserve the source Display P3 components and match the repository's existing `window-colorspace = display-p3` setting.

## Validation

- Converted all 16 ANSI colors plus background, foreground, cursor, selection, and bold colors from the source iTerm plist.
- Confirmed the Ghostty theme includes all required theme fields and 16 palette entries.
- Validated the Codex `.tmTheme` as well-formed XML.
- Re-fetched both branch files and confirmed they match the validated local artifacts exactly.