### PR TITLE
ci: keep Bonk on personal account endpoint

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -33,6 +33,7 @@ jobs:
           # CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
+          oidc_base_url: https://ask-bonk.silverlock.workers.dev/auth
           # model: cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.5
           # model: cloudflare-ai-gateway/anthropic/claude-opus-4-6
           model: opencode/claude-opus-4-6


### PR DESCRIPTION
This explicitly keeps Bonk on the personal Cloudflare endpoint now that the shared action defaults to the production account.